### PR TITLE
Fix missingInterpolationHandler to also call for objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [0.6.0-dev+1]
+
+* Fix `missingInterpolationHandler` to also be called for interpolations that do not result into String (and are not null)
+  e.g. `{{someVar}}` with no formats
+
 # [0.6.0-dev]
 
 * Adds `AssetBundleLocalizationDataSource.cache` property (default is still true)

--- a/lib/src/formatter.dart
+++ b/lib/src/formatter.dart
@@ -36,6 +36,15 @@ String? format(
     }
     return currentValue;
   });
+
+  if (result != null && result is! String) {
+    final formatter = options.missingInterpolationHandler;
+    if (formatter != null) {
+      return formatter(result, InterpolationFormat.fallback, locale, options)
+          ?.toString();
+    }
+  }
+
   return result?.toString();
 }
 

--- a/lib/src/interpolation_format.dart
+++ b/lib/src/interpolation_format.dart
@@ -11,7 +11,11 @@ import 'package:collection/collection.dart';
 /// `formatName()` = name='formatName' options=empty
 /// `formatName(op1: true; op2: some text)` = name='formatName' options={'op1': true, op2:'some text'}
 class InterpolationFormat {
-  InterpolationFormat(this.name, this.options);
+  const InterpolationFormat(this.name, this.options);
+
+  /// Special interpolation case where the value was not a [String], and no
+  /// other formats were found.
+  static const fallback = InterpolationFormat('fallback', {});
 
   /// The name of the format
   final String name;

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -187,9 +187,11 @@ class I18NextOptions with Diagnosticable {
   /// [I18Next.t].
   final MissingKeyHandler? missingKeyHandler;
 
-  /// Called when the interpolation format in [formats] is not found.
+  /// Called when the interpolation format in [formats] is not found, or when
+  /// the value being interpolated is not a [String].
   ///
-  /// The default behavior just returns the value itself.
+  /// The default behavior just returns the value itself (which will fallback
+  /// into a [Object.toString] call.
   final ValueFormatter? missingInterpolationHandler;
 
   /// A callback that is used when the translation failed while being evaluated


### PR DESCRIPTION
When the interpolation hasn't resolved into a string, it will call the
missingInterpolationHandler one last time before finishing.
