### PR TITLE
fix: count and context casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [Next version]
+
+* Fix `context` and `count` cast when they are inserted by variables
+  * They will now just be ignored and used for interpolation (if any)
+
 # [0.6.0-dev+3]
 
 * Adds `I18NextOptions.interpolationUnescapePrefix|interpolationUnescapeSuffix`

--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -54,8 +54,8 @@ class Translator {
     Map<String, dynamic> variables,
     I18NextOptions options,
   ) {
-    final context = variables['context'] as String?;
-    final count = variables['count'] as int?;
+    final context = _castAs<String>(variables['context']);
+    final count = _castAs<int>(variables['count']);
     final needsContext = context != null && context.isNotEmpty;
     final needsPlural = count != null;
 
@@ -141,4 +141,10 @@ class Translator {
     }
     return result;
   }
+}
+
+/// Dart casting syntax is not nullable safe
+/// `map['value'] as int?` will throw if the value is non int value
+T? _castAs<T>(dynamic value) {
+  return value is T ? value : null;
 }

--- a/test/i18next_test.dart
+++ b/test/i18next_test.dart
@@ -295,6 +295,13 @@ void main() {
       expect(i18next.t('$namespace:friend', count: 99), '99 friends');
     });
 
+    test('given key with count of another type', () {
+      expect(
+        i18next.t('$namespace:friend', variables: {'count': 'NOT INT'}),
+        'NOT INT friend',
+      );
+    });
+
     test('given key with count in Icelandic (alternate plural rule)', () {
       const ic = Locale('is');
       expect(i18next.t('$namespace:friend', count: 1, locale: ic), '1 vinur');
@@ -373,6 +380,13 @@ void main() {
     test('given key with mapped context', () {
       expect(i18next.t('$namespace:friend', context: 'male'), 'A boyfriend');
       expect(i18next.t('$namespace:friend', context: 'female'), 'A girlfriend');
+    });
+
+    test('given key with context of wrong type', () {
+      expect(
+        i18next.t('$namespace:friend', variables: {'context': 123.45}),
+        'A friend',
+      );
     });
 
     test('given key with mapped context in variables', () {


### PR DESCRIPTION
dart throws when trying to do a nullable type cast like so

```dart
someObject as int?
```

so we have to do a `is` check beforehand

```dart
someObject is int ? someObject as int : null;
```
