### PR TITLE
fix localization delegate synchronous loading of data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [0.7.3]
+
+- Don't schedule an extra microtask when loading a synchronous data source contents in `I18NextLocalizationDelegate`.
+  - [Issue #19](https://github.com/williamhjcho/i18next/issues/19) - thanks @wbusey0!
+
 # [0.7.2]
 
 - Updates sdk constraints to `>=2.18.0`
@@ -193,6 +198,6 @@ Internal:
 
 - Splits data fetching and translation into separate methods
 
-## [0.0.1] - TODO: Add release date.
+## [0.0.1] - TODO: Add release date
 
 - TODO: Describe initial release.

--- a/lib/src/i18next_localization_delegate.dart
+++ b/lib/src/i18next_localization_delegate.dart
@@ -75,14 +75,15 @@ class I18NextLocalizationDelegate extends LocalizationsDelegate<I18Next> {
   }
 
   @override
-  Future<I18Next> load(Locale locale) async {
+  Future<I18Next> load(Locale locale) {
     locale = normalizeLocale(locale);
 
-    final namespaces = await dataSource.load(locale);
-    // TODO: should delete previous locales/namespaces from resource store?
-    for (final entry in namespaces.entries) {
-      resourceStore.addNamespace(locale, entry.key, entry.value);
-    }
-    return I18Next(locale, resourceStore, options: options);
+    return dataSource.load(locale).then((namespaces) {
+      // TODO: should delete previous locales/namespaces from resource store?
+      for (final entry in namespaces.entries) {
+        resourceStore.addNamespace(locale, entry.key, entry.value);
+      }
+      return I18Next(locale, resourceStore, options: options);
+    });
   }
 }

--- a/test/i18next_localization_delegate_test.dart
+++ b/test/i18next_localization_delegate_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:i18next/i18next.dart';
@@ -98,6 +99,20 @@ void main() {
       expect(i18next.locale, en);
       verify(resourceStore.addNamespace(en, 'ns1', data1)).called(1);
       verify(resourceStore.addNamespace(en, 'ns2', data2)).called(1);
+    });
+
+    test('when dataSource is synchronous', () {
+      const data1 = <String, Object>{'key': 'ns1'};
+      when(dataSource.load(any)).thenAnswer(
+        (_) => SynchronousFuture({'ns1': data1}),
+      );
+
+      // checking if this is being called sync
+      I18Next? result;
+      localizationDelegate.load(en).then((value) => result = value);
+      expect(result, isNotNull);
+      expect(result!.locale, en);
+      verify(resourceStore.addNamespace(en, 'ns1', data1)).called(1);
     });
   });
 }


### PR DESCRIPTION
when the data source is synchronous, just do an extra microtask scheduling, keep chaining operations in the same stack/thread.

Fixes #19